### PR TITLE
Convert example modal to left side panel

### DIFF
--- a/src/app/_components/SidePanel.tsx
+++ b/src/app/_components/SidePanel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useEffect, ReactNode } from "react";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  width?: string;
+}
+
+export const SidePanel: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  children,
+  width = "500px",
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ${
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onClose}
+      />
+      <div
+        className={`fixed inset-y-0 left-0 z-50 w-full max-w-[${width}] transform bg-white shadow-xl transition-transform duration-300 ${
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <button
+          type="button"
+          className="absolute right-2 top-2 p-3"
+          onClick={onClose}
+        >
+          <FontAwesomeIcon
+            className="text-[34px] text-[#ACAAA9]"
+            icon={faXmark}
+          />
+        </button>
+        <div className="h-full overflow-auto pt-6">{children}</div>
+      </div>
+    </>
+  );
+};

--- a/src/app/_components/SidePanel.tsx
+++ b/src/app/_components/SidePanel.tsx
@@ -2,20 +2,20 @@
 
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { useEffect, ReactNode } from "react";
+import React, { useEffect, ReactNode, useMemo } from "react";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
-  width?: string;
+  maxWidth?: string;
 }
 
 export const SidePanel: React.FC<Props> = ({
   isOpen,
   onClose,
   children,
-  width = "500px",
+  maxWidth = "500px",
 }) => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -27,16 +27,15 @@ export const SidePanel: React.FC<Props> = ({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
+  const mw = useMemo(() => `max-w-[${maxWidth}]`, [maxWidth]);
+
   return (
     <>
       <div
-        className={`fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ${
-          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
-        }`}
-        onClick={onClose}
+      // onClick={onClose}
       />
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-full max-w-[${width}] transform bg-white shadow-xl transition-transform duration-300 ${
+        className={`fixed inset-y-0 left-0 z-50 w-full bg-white shadow-xl transition-transform duration-300 ${mw} ${
           isOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
@@ -50,7 +49,7 @@ export const SidePanel: React.FC<Props> = ({
             icon={faXmark}
           />
         </button>
-        <div className="h-full overflow-auto pt-6">{children}</div>
+        <div className="h-full overflow-auto">{children}</div>
       </div>
     </>
   );

--- a/src/app/q/[questionId]/_components/ExampleAnswerModal.tsx
+++ b/src/app/q/[questionId]/_components/ExampleAnswerModal.tsx
@@ -34,7 +34,7 @@ export const ExampleAnswerModal: React.FC<Props> = ({
   }, [files, selectedFileId]);
 
   return (
-    <SidePanel isOpen={isOpen} onClose={onClose}>
+    <SidePanel isOpen={isOpen} onClose={onClose} maxWidth="800px">
       <div className="w-full space-y-4 pt-4">
         <div className="flex items-center justify-between">
           <p className="text-lg font-bold">「{title}」の模範回答例</p>

--- a/src/app/q/[questionId]/_components/ExampleAnswerModal.tsx
+++ b/src/app/q/[questionId]/_components/ExampleAnswerModal.tsx
@@ -6,7 +6,7 @@ import { QuestionFile } from "@prisma/client";
 import React, { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { FileTabs } from "../../../_components/CodeEditor/FileTabs";
-import { Modal } from "@/app/_components/Modal";
+import { SidePanel } from "@/app/_components/SidePanel";
 
 interface Props {
   title: string;
@@ -34,8 +34,8 @@ export const ExampleAnswerModal: React.FC<Props> = ({
   }, [files, selectedFileId]);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
-      <div className="w-full max-w-[800px] space-y-4 pt-4">
+    <SidePanel isOpen={isOpen} onClose={onClose}>
+      <div className="w-full space-y-4 pt-4">
         <div className="flex items-center justify-between">
           <p className="text-lg font-bold">「{title}」の模範回答例</p>
         </div>
@@ -70,6 +70,6 @@ export const ExampleAnswerModal: React.FC<Props> = ({
           </button>
         </div>
       </div>
-    </Modal>
+    </SidePanel>
   );
 };


### PR DESCRIPTION
## Summary
- add `SidePanel` component for sliding panels
- show example answer in a side panel instead of centered modal

## Testing
- `npm run lint` *(fails: `next: not found`)*